### PR TITLE
Expose results of name resolution

### DIFF
--- a/crates/wast/src/ast/module.rs
+++ b/crates/wast/src/ast/module.rs
@@ -1,6 +1,8 @@
 use crate::ast::{self, kw};
 use crate::parser::{Parse, Parser, Result};
 
+pub use crate::resolve::Names;
+
 /// A `*.wat` file parser, or a parser for one parenthesized module.
 ///
 /// This is the top-level type which you'll frequently parse when working with
@@ -51,7 +53,7 @@ pub enum ModuleKind<'a> {
     Binary(Vec<&'a [u8]>),
 }
 
-impl Module<'_> {
+impl<'a> Module<'a> {
     /// Performs a name resolution pass on this [`Module`], resolving all
     /// symbolic names to indices.
     ///
@@ -67,16 +69,16 @@ impl Module<'_> {
     /// exports/imports listed on fields and handle various other shorthands of
     /// the text format.
     ///
-    /// If successful, nothing is returned, and the AST was modified to be ready
-    /// for binary encoding.
+    /// If successful the AST was modified to be ready for binary encoding. A
+    /// [`Names`] structure is also returned so if you'd like to do your own
+    /// name lookups on the result you can do so as well.
     ///
     /// # Errors
     ///
     /// If an error happens during resolution, such a name resolution error or
     /// items are found in the wrong order, then an error is returned.
-    fn resolve(&mut self) -> std::result::Result<(), crate::Error> {
-        crate::resolve::resolve(self)?;
-        Ok(())
+    pub fn resolve(&mut self) -> std::result::Result<Names<'a>, crate::Error> {
+        crate::resolve::resolve(self)
     }
 
     /// Encodes this [`Module`] to its binary form.

--- a/crates/wast/src/lib.rs
+++ b/crates/wast/src/lib.rs
@@ -124,8 +124,12 @@ impl Error {
         return ret;
     }
 
-    #[cfg(feature = "wasm-module")]
-    fn new(span: Span, message: String) -> Error {
+    /// Creates a new error with the given `message` which is targeted at the
+    /// given `span`
+    ///
+    /// Note that you'll want to ensure that `set_text` or `set_path` is called
+    /// on the resulting error to improve the rendering of the error message.
+    pub fn new(span: Span, message: String) -> Error {
         Error {
             inner: Box::new(ErrorInner {
                 text: None,

--- a/crates/wast/src/resolve/names.rs
+++ b/crates/wast/src/resolve/names.rs
@@ -3,7 +3,7 @@ use crate::Error;
 use std::collections::HashMap;
 
 #[derive(Copy, Clone)]
-enum Ns {
+pub enum Ns {
     Data,
     Elem,
     Func,
@@ -205,7 +205,7 @@ impl<'a> Resolver<'a> {
         ExprResolver::new(self, span).resolve(expr)
     }
 
-    fn resolve_idx(&self, idx: &mut Index<'a>, ns: Ns) -> Result<(), Error> {
+    pub fn resolve_idx(&self, idx: &mut Index<'a>, ns: Ns) -> Result<(), Error> {
         match self.ns(ns).resolve(idx) {
             Ok(_n) => Ok(()),
             Err(id) => Err(self.resolve_error(id, ns.desc())),


### PR DESCRIPTION
This commit exposes the `Module::resolve` method which allows accessing
the results of name resolution. The thinking here is that formats like
wasm interface types will want to access the function indices of the
core module but by name as well, so we can expose the results of name
resolution so the interface types section can access the same results.