### PR TITLE
Parse `anyfunc` as a value type

### DIFF
--- a/crates/wast/src/ast/types.rs
+++ b/crates/wast/src/ast/types.rs
@@ -35,6 +35,9 @@ impl<'a> Parse<'a> for ValType {
         } else if l.peek::<kw::funcref>() {
             parser.parse::<kw::funcref>()?;
             Ok(ValType::Funcref)
+        } else if l.peek::<kw::anyfunc>() {
+            parser.parse::<kw::anyfunc>()?;
+            Ok(ValType::Funcref)
         } else if l.peek::<kw::v128>() {
             parser.parse::<kw::v128>()?;
             Ok(ValType::V128)


### PR DESCRIPTION
Looks like this is an old shorthand!