### PR TITLE
Add SIMD variants of assert_return_canonical_nan and assert_return_arithmetic_nan

### DIFF
--- a/crates/wast/src/ast/mod.rs
+++ b/crates/wast/src/ast/mod.rs
@@ -106,7 +106,11 @@ pub mod kw {
     custom_keyword!(assert_malformed);
     custom_keyword!(assert_return);
     custom_keyword!(assert_return_arithmetic_nan);
+    custom_keyword!(assert_return_arithmetic_nan_f32x4);
+    custom_keyword!(assert_return_arithmetic_nan_f64x2);
     custom_keyword!(assert_return_canonical_nan);
+    custom_keyword!(assert_return_canonical_nan_f32x4);
+    custom_keyword!(assert_return_canonical_nan_f64x2);
     custom_keyword!(assert_return_func);
     custom_keyword!(assert_trap);
     custom_keyword!(assert_unlinkable);


### PR DESCRIPTION
@alexcrichton, I [had hoped] that the changes to `assert_return` would come sooner but since it has been a couple of weeks I decided to just implement the current versions of `assert_return_*_nan`. I'll close #24 in favor of this and once https://github.com/WebAssembly/spec/pull/1104 is merged and trickles downstream we can remove these variants.

[had hoped]: https://github.com/bytecodealliance/wat/pull/24#issuecomment-555256729