### PR TITLE
Add support for `nan:canonical` and `nan:arithmetic` in `assert_return`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ exclude = ['tests/wabt']
 members = ['fuzz']
 
 [dependencies]
-wast = { path = 'crates/wast', version = '5.0.0' }
+wast = { path = 'crates/wast', version = '6.0.0' }
 
 [dev-dependencies]
 anyhow = "1.0"

--- a/crates/wast/Cargo.toml
+++ b/crates/wast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wast"
-version = "5.0.1"
+version = "6.0.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 edition = "2018"
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/wast/src/ast/assert_expr.rs
+++ b/crates/wast/src/ast/assert_expr.rs
@@ -19,7 +19,6 @@ pub enum AssertExpression<'a> {
     V128(V128Pattern),
 
     RefNull,
-    RefIsNull,
     RefHost(u32),
     RefFunc(Index<'a>),
 
@@ -43,7 +42,6 @@ impl <'a> Parse<'a> for AssertExpression<'a> {
             "f64.const" => Ok(AssertExpression::F64(parser.parse()?)),
             "v128.const" => Ok(AssertExpression::V128(parser.parse()?)),
             "ref.null" => Ok(AssertExpression::RefNull),
-            "ref.is_null" => Ok(AssertExpression::RefIsNull),
             "ref.host" => Ok(AssertExpression::RefHost(parser.parse()?)),
             "ref.func" => Ok(AssertExpression::RefFunc(parser.parse()?)),
             _ => Err(parser.error("expected a [type].const expression"))

--- a/crates/wast/src/ast/assert_expr.rs
+++ b/crates/wast/src/ast/assert_expr.rs
@@ -1,6 +1,5 @@
 use crate::ast::{kw, Float32, Float64, Index};
 use crate::parser::{Parse, Parser, Result};
-use crate::WastDirective::AssertReturn;
 
 /// An expression that is valid inside an `assert_return` directive.
 ///
@@ -22,7 +21,6 @@ pub enum AssertExpression<'a> {
     RefHost(u32),
     RefFunc(Index<'a>),
 
-    #[deprecated(since = "6.0.0", note = "Please use F32/F64 instead; this is only included for parsing the legacy `assert_return_*` directives and should be removed when they are.")]
     LegacyNaN,
 }
 

--- a/crates/wast/src/ast/assert_expr.rs
+++ b/crates/wast/src/ast/assert_expr.rs
@@ -16,6 +16,8 @@ pub enum AssertExpression {
     F32(NanPattern<Float32>),
     F64(NanPattern<Float64>),
     V128(V128Pattern),
+    #[deprecated(since = "6.0.0", note = "Please use F32/F64 instead; this is only included for parsing the legacy `assert_return_*` directives and should be removed when they are.")]
+    LegacyNaN,
 }
 
 impl <'a> Parse<'a> for AssertExpression {

--- a/crates/wast/src/ast/assert_expr.rs
+++ b/crates/wast/src/ast/assert_expr.rs
@@ -21,7 +21,10 @@ pub enum AssertExpression<'a> {
     RefHost(u32),
     RefFunc(Index<'a>),
 
-    LegacyNaN,
+    // Either matches an f32 or f64 for an arithmetic nan pattern
+    LegacyArithmeticNaN,
+    // Either matches an f32 or f64 for a canonical nan pattern
+    LegacyCanonicalNaN,
 }
 
 impl <'a> Parse<'a> for AssertExpression<'a> {

--- a/crates/wast/src/ast/assert_expr.rs
+++ b/crates/wast/src/ast/assert_expr.rs
@@ -1,0 +1,141 @@
+use crate::ast::{kw, Float32, Float64};
+use crate::parser::{Parse, Parser, Result};
+
+/// An expression that is valid inside an `assert_return` directive.
+///
+/// As of https://github.com/WebAssembly/spec/pull/1104, spec tests may include `assert_return`
+/// directives that allow NaN patterns (`"nan:canonical"`, `"nan:arithmetic"`). Parsing an
+/// `AssertExpression` means that:
+/// - only constant values (e.g. `i32.const 4`) are used in the `assert_return` directive
+/// - the NaN patterns are allowed (they are not allowed in regular `Expression`s).
+#[derive(Debug)]
+#[allow(missing_docs)]
+pub enum AssertExpression {
+    I32(i32),
+    I64(i64),
+    F32(NanPattern<Float32>),
+    F64(NanPattern<Float64>),
+    V128(V128Pattern),
+}
+
+impl <'a> Parse<'a> for AssertExpression {
+    fn parse(parser: Parser<'a>) -> Result<Self> {
+        let keyword = parser.step(|c| {
+            match c.keyword() {
+                Some(pair) => Ok(pair),
+                None => Err(c.error("expected a keyword")),
+            }
+        })?;
+
+        match keyword {
+            "i32.const" => Ok(AssertExpression::I32(parser.parse()?)),
+            "i64.const" => Ok(AssertExpression::I64(parser.parse()?)),
+            "f32.const" => Ok(AssertExpression::F32(parser.parse()?)),
+            "f64.const" => Ok(AssertExpression::F64(parser.parse()?)),
+            "v128.const" => Ok(AssertExpression::V128(parser.parse()?)),
+            _ => Err(parser.error("expected a [type].const expression"))
+        }
+    }
+}
+
+/// Either a NaN pattern (`nan:canonical`, `nan:arithmetic`) or a value of type `T`.
+#[derive(Debug, PartialEq)]
+#[allow(missing_docs)]
+pub enum NanPattern<T> {
+    CanonicalNan,
+    ArithmeticNan,
+    Value(T)
+}
+
+impl <'a, T> Parse<'a> for NanPattern<T> where T: Parse<'a> {
+    fn parse(parser: Parser<'a>) -> Result<Self> {
+        if parser.peek::<kw::nan_canonical>() {
+            parser.parse::<kw::nan_canonical>()?;
+            Ok(NanPattern::CanonicalNan)
+        } else if parser.peek::<kw::nan_arithmetic>() {
+            parser.parse::<kw::nan_arithmetic>()?;
+            Ok(NanPattern::ArithmeticNan)
+        } else {
+            let val = parser.parse()?;
+            Ok(NanPattern::Value(val))
+        }
+    }
+}
+
+/// A version of `V128Const` that allows `NanPattern`s.
+///
+/// This implementation is necessary because only float types can include NaN patterns; otherwise
+/// it is largely similar to the implementation of `V128Const`.
+#[derive(Debug)]
+#[allow(missing_docs)]
+pub enum V128Pattern {
+    I8x16([i8; 16]),
+    I16x8([i16; 8]),
+    I32x4([i32; 4]),
+    I64x2([i64; 2]),
+    F32x4([NanPattern<Float32>; 4]),
+    F64x2([NanPattern<Float64>; 2]),
+}
+
+impl<'a> Parse<'a> for V128Pattern {
+    fn parse(parser: Parser<'a>) -> Result<Self> {
+        let mut l = parser.lookahead1();
+        if l.peek::<kw::i8x16>() {
+            parser.parse::<kw::i8x16>()?;
+            Ok(V128Pattern::I8x16([
+                parser.parse()?,
+                parser.parse()?,
+                parser.parse()?,
+                parser.parse()?,
+                parser.parse()?,
+                parser.parse()?,
+                parser.parse()?,
+                parser.parse()?,
+                parser.parse()?,
+                parser.parse()?,
+                parser.parse()?,
+                parser.parse()?,
+                parser.parse()?,
+                parser.parse()?,
+                parser.parse()?,
+                parser.parse()?,
+            ]))
+        } else if l.peek::<kw::i16x8>() {
+            parser.parse::<kw::i16x8>()?;
+            Ok(V128Pattern::I16x8([
+                parser.parse()?,
+                parser.parse()?,
+                parser.parse()?,
+                parser.parse()?,
+                parser.parse()?,
+                parser.parse()?,
+                parser.parse()?,
+                parser.parse()?,
+            ]))
+        } else if l.peek::<kw::i32x4>() {
+            parser.parse::<kw::i32x4>()?;
+            Ok(V128Pattern::I32x4([
+                parser.parse()?,
+                parser.parse()?,
+                parser.parse()?,
+                parser.parse()?,
+            ]))
+        } else if l.peek::<kw::i64x2>() {
+            parser.parse::<kw::i64x2>()?;
+            Ok(V128Pattern::I64x2([parser.parse()?, parser.parse()?]))
+        } else if l.peek::<kw::f32x4>() {
+            parser.parse::<kw::f32x4>()?;
+            Ok(V128Pattern::F32x4([
+                parser.parse()?,
+                parser.parse()?,
+                parser.parse()?,
+                parser.parse()?,
+            ]))
+        } else if l.peek::<kw::f64x2>() {
+            parser.parse::<kw::f64x2>()?;
+            Ok(V128Pattern::F64x2([parser.parse()?, parser.parse()?]))
+        } else {
+            Err(l.error())
+        }
+    }
+}

--- a/crates/wast/src/ast/mod.rs
+++ b/crates/wast/src/ast/mod.rs
@@ -85,6 +85,7 @@ reexport! {
 
 #[cfg(feature = "wasm-module")]
 reexport! {
+    mod assert_expr;
     mod export;
     mod expr;
     mod func;

--- a/crates/wast/src/ast/mod.rs
+++ b/crates/wast/src/ast/mod.rs
@@ -139,6 +139,8 @@ pub mod kw {
     custom_keyword!(local);
     custom_keyword!(memory);
     custom_keyword!(module);
+    custom_keyword!(nan_arithmetic = "nan:arithmetic");
+    custom_keyword!(nan_canonical = "nan:canonical");
     custom_keyword!(nullref);
     custom_keyword!(offset);
     custom_keyword!(param);

--- a/crates/wast/src/ast/wast.rs
+++ b/crates/wast/src/ast/wast.rs
@@ -1,5 +1,6 @@
 use crate::ast::{self, kw};
 use crate::parser::{Cursor, Parse, Parser, Peek, Result};
+use crate::AssertExpression;
 
 /// A parsed representation of a `*.wast` file.
 ///
@@ -78,30 +79,6 @@ pub enum WastDirective<'a> {
         exec: WastExecute<'a>,
         results: Vec<ast::AssertExpression>,
     },
-    AssertReturnCanonicalNan {
-        span: ast::Span,
-        invoke: WastInvoke<'a>,
-    },
-    AssertReturnCanonicalNanF32x4 {
-        span: ast::Span,
-        invoke: WastInvoke<'a>,
-    },
-    AssertReturnCanonicalNanF64x2 {
-        span: ast::Span,
-        invoke: WastInvoke<'a>,
-    },
-    AssertReturnArithmeticNan {
-        span: ast::Span,
-        invoke: WastInvoke<'a>,
-    },
-    AssertReturnArithmeticNanF32x4 {
-        span: ast::Span,
-        invoke: WastInvoke<'a>,
-    },
-    AssertReturnArithmeticNanF64x2 {
-        span: ast::Span,
-        invoke: WastInvoke<'a>,
-    },
     AssertReturnFunc {
         span: ast::Span,
         invoke: WastInvoke<'a>,
@@ -127,12 +104,6 @@ impl WastDirective<'_> {
             WastDirective::Register { span, .. } |
             WastDirective::AssertTrap { span, .. } |
             WastDirective::AssertReturn { span, .. } |
-            WastDirective::AssertReturnCanonicalNan { span, .. } |
-            WastDirective::AssertReturnCanonicalNanF32x4 { span, .. } |
-            WastDirective::AssertReturnCanonicalNanF64x2 { span, .. } |
-            WastDirective::AssertReturnArithmeticNan { span, .. } |
-            WastDirective::AssertReturnArithmeticNanF32x4 { span, .. } |
-            WastDirective::AssertReturnArithmeticNanF64x2 { span, .. } |
             WastDirective::AssertReturnFunc { span, .. } |
             WastDirective::AssertExhaustion { span, .. } |
             WastDirective::AssertUnlinkable { span, .. } |
@@ -191,39 +162,45 @@ impl<'a> Parse<'a> for WastDirective<'a> {
             })
         } else if l.peek::<kw::assert_return_canonical_nan>() {
             let span = parser.parse::<kw::assert_return_canonical_nan>()?.0;
-            Ok(WastDirective::AssertReturnCanonicalNan {
+            Ok(WastDirective::AssertReturn {
                 span,
-                invoke: parser.parens(|p| p.parse())?,
+                exec: parser.parens(|p| p.parse())?,
+                results: vec![AssertExpression::LegacyNaN]
             })
         } else if l.peek::<kw::assert_return_canonical_nan_f32x4>() {
             let span = parser.parse::<kw::assert_return_canonical_nan_f32x4>()?.0;
-            Ok(WastDirective::AssertReturnCanonicalNanF32x4 {
+            Ok(WastDirective::AssertReturn {
                 span,
-                invoke: parser.parens(|p| p.parse())?,
+                exec: parser.parens(|p| p.parse())?,
+                results: vec![AssertExpression::LegacyNaN]
             })
         } else if l.peek::<kw::assert_return_canonical_nan_f64x2>() {
             let span = parser.parse::<kw::assert_return_canonical_nan_f64x2>()?.0;
-            Ok(WastDirective::AssertReturnCanonicalNanF64x2 {
+            Ok(WastDirective::AssertReturn {
                 span,
-                invoke: parser.parens(|p| p.parse())?,
+                exec: parser.parens(|p| p.parse())?,
+                results: vec![AssertExpression::LegacyNaN]
             })
         } else if l.peek::<kw::assert_return_arithmetic_nan>() {
             let span = parser.parse::<kw::assert_return_arithmetic_nan>()?.0;
-            Ok(WastDirective::AssertReturnArithmeticNan {
+            Ok(WastDirective::AssertReturn {
                 span,
-                invoke: parser.parens(|p| p.parse())?,
+                exec: parser.parens(|p| p.parse())?,
+                results: vec![AssertExpression::LegacyNaN]
             })
         } else if l.peek::<kw::assert_return_arithmetic_nan_f32x4>() {
             let span = parser.parse::<kw::assert_return_arithmetic_nan_f32x4>()?.0;
-            Ok(WastDirective::AssertReturnArithmeticNanF32x4 {
+            Ok(WastDirective::AssertReturn {
                 span,
-                invoke: parser.parens(|p| p.parse())?,
+                exec: parser.parens(|p| p.parse())?,
+                results: vec![AssertExpression::LegacyNaN]
             })
         } else if l.peek::<kw::assert_return_arithmetic_nan_f64x2>() {
             let span = parser.parse::<kw::assert_return_arithmetic_nan_f64x2>()?.0;
-            Ok(WastDirective::AssertReturnArithmeticNanF64x2 {
+            Ok(WastDirective::AssertReturn {
                 span,
-                invoke: parser.parens(|p| p.parse())?,
+                exec: parser.parens(|p| p.parse())?,
+                results: vec![AssertExpression::LegacyNaN]
             })
         } else if l.peek::<kw::assert_return_func>() {
             let span = parser.parse::<kw::assert_return_func>()?.0;
@@ -343,9 +320,9 @@ mod tests {
 
     #[test]
     fn assert_nan() {
-        assert_parses_to_directive!("assert_return_canonical_nan_f32x4 (invoke \"foo\" (f32.const 0))", WastDirective::AssertReturnCanonicalNanF32x4 { .. });
-        assert_parses_to_directive!("assert_return_canonical_nan_f64x2 (invoke \"foo\" (f32.const 0))", WastDirective::AssertReturnCanonicalNanF64x2 { .. });
-        assert_parses_to_directive!("assert_return_arithmetic_nan_f32x4 (invoke \"foo\" (f32.const 0))", WastDirective::AssertReturnArithmeticNanF32x4 { .. });
-        assert_parses_to_directive!("assert_return_arithmetic_nan_f64x2 (invoke \"foo\" (f32.const 0))", WastDirective::AssertReturnArithmeticNanF64x2 { .. });
+        assert_parses_to_directive!("assert_return_canonical_nan_f32x4 (invoke \"foo\" (f32.const 0))", WastDirective::AssertReturn { .. });
+        assert_parses_to_directive!("assert_return_canonical_nan_f64x2 (invoke \"foo\" (f32.const 0))", WastDirective::AssertReturn { .. });
+        assert_parses_to_directive!("assert_return_arithmetic_nan_f32x4 (invoke \"foo\" (f32.const 0))", WastDirective::AssertReturn { .. });
+        assert_parses_to_directive!("assert_return_arithmetic_nan_f64x2 (invoke \"foo\" (f32.const 0))", WastDirective::AssertReturn { .. });
     }
 }

--- a/crates/wast/src/ast/wast.rs
+++ b/crates/wast/src/ast/wast.rs
@@ -1,6 +1,6 @@
 use crate::ast::{self, kw};
 use crate::parser::{Cursor, Parse, Parser, Peek, Result};
-use crate::AssertExpression;
+use crate::{AssertExpression, NanPattern, V128Pattern};
 
 /// A parsed representation of a `*.wast` file.
 ///
@@ -165,42 +165,62 @@ impl<'a> Parse<'a> for WastDirective<'a> {
             Ok(WastDirective::AssertReturn {
                 span,
                 exec: parser.parens(|p| p.parse())?,
-                results: vec![AssertExpression::LegacyNaN]
+                results: vec![AssertExpression::LegacyCanonicalNaN]
             })
         } else if l.peek::<kw::assert_return_canonical_nan_f32x4>() {
             let span = parser.parse::<kw::assert_return_canonical_nan_f32x4>()?.0;
+            let pat = V128Pattern::F32x4([
+                NanPattern::CanonicalNan,
+                NanPattern::CanonicalNan,
+                NanPattern::CanonicalNan,
+                NanPattern::CanonicalNan,
+            ]);
             Ok(WastDirective::AssertReturn {
                 span,
                 exec: parser.parens(|p| p.parse())?,
-                results: vec![AssertExpression::LegacyNaN]
+                results: vec![AssertExpression::V128(pat)]
             })
         } else if l.peek::<kw::assert_return_canonical_nan_f64x2>() {
             let span = parser.parse::<kw::assert_return_canonical_nan_f64x2>()?.0;
+            let pat = V128Pattern::F64x2([
+                NanPattern::CanonicalNan,
+                NanPattern::CanonicalNan,
+            ]);
             Ok(WastDirective::AssertReturn {
                 span,
                 exec: parser.parens(|p| p.parse())?,
-                results: vec![AssertExpression::LegacyNaN]
+                results: vec![AssertExpression::V128(pat)]
             })
         } else if l.peek::<kw::assert_return_arithmetic_nan>() {
             let span = parser.parse::<kw::assert_return_arithmetic_nan>()?.0;
             Ok(WastDirective::AssertReturn {
                 span,
                 exec: parser.parens(|p| p.parse())?,
-                results: vec![AssertExpression::LegacyNaN]
+                results: vec![AssertExpression::LegacyArithmeticNaN]
             })
         } else if l.peek::<kw::assert_return_arithmetic_nan_f32x4>() {
             let span = parser.parse::<kw::assert_return_arithmetic_nan_f32x4>()?.0;
+            let pat = V128Pattern::F32x4([
+                NanPattern::ArithmeticNan,
+                NanPattern::ArithmeticNan,
+                NanPattern::ArithmeticNan,
+                NanPattern::ArithmeticNan,
+            ]);
             Ok(WastDirective::AssertReturn {
                 span,
                 exec: parser.parens(|p| p.parse())?,
-                results: vec![AssertExpression::LegacyNaN]
+                results: vec![AssertExpression::V128(pat)]
             })
         } else if l.peek::<kw::assert_return_arithmetic_nan_f64x2>() {
             let span = parser.parse::<kw::assert_return_arithmetic_nan_f64x2>()?.0;
+            let pat = V128Pattern::F64x2([
+                NanPattern::ArithmeticNan,
+                NanPattern::ArithmeticNan,
+            ]);
             Ok(WastDirective::AssertReturn {
                 span,
                 exec: parser.parens(|p| p.parse())?,
-                results: vec![AssertExpression::LegacyNaN]
+                results: vec![AssertExpression::V128(pat)]
             })
         } else if l.peek::<kw::assert_return_func>() {
             let span = parser.parse::<kw::assert_return_func>()?.0;

--- a/crates/wast/src/ast/wast.rs
+++ b/crates/wast/src/ast/wast.rs
@@ -77,7 +77,7 @@ pub enum WastDirective<'a> {
     AssertReturn {
         span: ast::Span,
         exec: WastExecute<'a>,
-        results: Vec<ast::AssertExpression>,
+        results: Vec<ast::AssertExpression<'a>>,
     },
     AssertReturnFunc {
         span: ast::Span,

--- a/crates/wast/src/ast/wast.rs
+++ b/crates/wast/src/ast/wast.rs
@@ -76,7 +76,7 @@ pub enum WastDirective<'a> {
     AssertReturn {
         span: ast::Span,
         exec: WastExecute<'a>,
-        results: Vec<ast::Expression<'a>>,
+        results: Vec<ast::AssertExpression>,
     },
     AssertReturnCanonicalNan {
         span: ast::Span,


### PR DESCRIPTION
This creates a new `AssertExpression` type that parses `[type].const [value]` expressions in a way that allows the `nan:canonical` and `nan:arithmetic` patterns to appear in these expressions; this is separate from the `Expression` implementation to disallow using these patterns in regular code (they are only valid in `assert_return` directives).