### PR TITLE
Parse negative index values for SIMD lanes

### DIFF
--- a/crates/wast/src/ast/expr.rs
+++ b/crates/wast/src/ast/expr.rs
@@ -1008,7 +1008,7 @@ impl<'a> Parse<'a> for V128Const {
 #[derive(Debug)]
 pub struct V8x16Shuffle {
     #[allow(missing_docs)]
-    pub lanes: [u8; 16],
+    pub lanes: [i8; 16],
 }
 
 impl<'a> Parse<'a> for V8x16Shuffle {

--- a/crates/wast/src/binary.rs
+++ b/crates/wast/src/binary.rs
@@ -668,7 +668,8 @@ impl Encode for V128Const {
 
 impl Encode for V8x16Shuffle {
     fn encode(&self, dst: &mut Vec<u8>) {
-        dst.extend_from_slice(&self.lanes);
+        let indexes: Vec<u8> = self.lanes.iter().map(|&i| i as u8).collect();
+        dst.extend_from_slice(&indexes);
     }
 }
 


### PR DESCRIPTION
This parses negative index values in SIMD lanes (see https://github.com/WebAssembly/testsuite/blob/c70c3c8b136e5e7193135d40ec3960f4ef1cb20a/proposals/simd/simd_lane.wast#L492); wasmparser should catch this incorrect index during validation at https://github.com/bytecodealliance/wasmparser/blob/fb3185bb70243196fb2ff56b28cf497a51756085/src/binary_reader.rs#L1357. Closes #44.