### PR TITLE
Some tweaks for upcoming simd spec changes

### DIFF
--- a/crates/wast/src/ast/expr.rs
+++ b/crates/wast/src/ast/expr.rs
@@ -505,25 +505,25 @@ instructions! {
         V128Const(V128Const) : [0xfd, 0x02] : "v128.const",
 
         I8x16Splat : [0xfd, 0x04] : "i8x16.splat",
-        I8x16ExtractLaneS(i32) : [0xfd, 0x05] : "i8x16.extract_lane_s",
-        I8x16ExtractLaneU(i32) : [0xfd, 0x06] : "i8x16.extract_lane_u",
-        I8x16ReplaceLane(i32) : [0xfd, 0x07] : "i8x16.replace_lane",
+        I8x16ExtractLaneS(u8) : [0xfd, 0x05] : "i8x16.extract_lane_s",
+        I8x16ExtractLaneU(u8) : [0xfd, 0x06] : "i8x16.extract_lane_u",
+        I8x16ReplaceLane(u8) : [0xfd, 0x07] : "i8x16.replace_lane",
         I16x8Splat : [0xfd, 0x08] : "i16x8.splat",
-        I16x8ExtractLaneS(i32) : [0xfd, 0x09] : "i16x8.extract_lane_s",
-        I16x8ExtractLaneU(i32) : [0xfd, 0x0a] : "i16x8.extract_lane_u",
-        I16x8ReplaceLane(i32) : [0xfd, 0x0b] : "i16x8.replace_lane",
+        I16x8ExtractLaneS(u8) : [0xfd, 0x09] : "i16x8.extract_lane_s",
+        I16x8ExtractLaneU(u8) : [0xfd, 0x0a] : "i16x8.extract_lane_u",
+        I16x8ReplaceLane(u8) : [0xfd, 0x0b] : "i16x8.replace_lane",
         I32x4Splat : [0xfd, 0x0c] : "i32x4.splat",
-        I32x4ExtractLane(i32) : [0xfd, 0x0d] : "i32x4.extract_lane",
-        I32x4ReplaceLane(i32) : [0xfd, 0x0e] : "i32x4.replace_lane",
+        I32x4ExtractLane(u8) : [0xfd, 0x0d] : "i32x4.extract_lane",
+        I32x4ReplaceLane(u8) : [0xfd, 0x0e] : "i32x4.replace_lane",
         I64x2Splat : [0xfd, 0x0f] : "i64x2.splat",
-        I64x2ExtractLane(i32) : [0xfd, 0x10] : "i64x2.extract_lane",
-        I64x2ReplaceLane(i32) : [0xfd, 0x11] : "i64x2.replace_lane",
+        I64x2ExtractLane(u8) : [0xfd, 0x10] : "i64x2.extract_lane",
+        I64x2ReplaceLane(u8) : [0xfd, 0x11] : "i64x2.replace_lane",
         F32x4Splat : [0xfd, 0x12] : "f32x4.splat",
-        F32x4ExtractLane(i32) : [0xfd, 0x13] : "f32x4.extract_lane",
-        F32x4ReplaceLane(i32) : [0xfd, 0x14] : "f32x4.replace_lane",
+        F32x4ExtractLane(u8) : [0xfd, 0x13] : "f32x4.extract_lane",
+        F32x4ReplaceLane(u8) : [0xfd, 0x14] : "f32x4.replace_lane",
         F64x2Splat : [0xfd, 0x15] : "f64x2.splat",
-        F64x2ExtractLane(i32) : [0xfd, 0x16] : "f64x2.extract_lane",
-        F64x2ReplaceLane(i32) : [0xfd, 0x17] : "f64x2.replace_lane",
+        F64x2ExtractLane(u8) : [0xfd, 0x16] : "f64x2.extract_lane",
+        F64x2ReplaceLane(u8) : [0xfd, 0x17] : "f64x2.replace_lane",
 
         I8x16Eq : [0xfd, 0x18] : "i8x16.eq",
         I8x16Ne : [0xfd, 0x19] : "i8x16.ne",
@@ -657,12 +657,8 @@ instructions! {
 
         I32x4TruncSatF32x4S : [0xfd, 0xab] : "i32x4.trunc_sat_f32x4_s",
         I32x4TruncSatF32x4U : [0xfd, 0xac] : "i32x4.trunc_sat_f32x4_u",
-        I64x2TruncSatF64x2S : [0xfd, 0xad] : "i64x2.trunc_sat_f64x2_s",
-        I64x2TruncSatF64x2U : [0xfd, 0xae] : "i64x2.trunc_sat_f64x2_u",
         F32x4ConvertI32x4S : [0xfd, 0xaf] : "f32x4.convert_i32x4_s",
         F32x4ConvertI32x4U : [0xfd, 0xb0] : "f32x4.convert_i32x4_u",
-        F64x2ConvertI64x2S : [0xfd, 0xb1] : "f64x2.convert_i64x2_s",
-        F64x2ConvertI64x2U : [0xfd, 0xb2] : "f64x2.convert_i64x2_u",
         V8x16Swizzle : [0xfd, 0xc0] : "v8x16.swizzle",
         V8x16Shuffle(V8x16Shuffle) : [0xfd, 0xc1] : "v8x16.shuffle",
         V8x16LoadSplat(MemArg<1>) : [0xfd, 0xc2] : "v8x16.load_splat",
@@ -1020,7 +1016,7 @@ impl<'a> Parse<'a> for V128Const {
 #[derive(Debug)]
 pub struct V8x16Shuffle {
     #[allow(missing_docs)]
-    pub lanes: [i8; 16],
+    pub lanes: [u8; 16],
 }
 
 impl<'a> Parse<'a> for V8x16Shuffle {

--- a/crates/wast/src/binary.rs
+++ b/crates/wast/src/binary.rs
@@ -109,13 +109,6 @@ impl<T: Encode> Encode for [T] {
     }
 }
 
-impl Encode for [u8] {
-    fn encode(&self, e: &mut Vec<u8>) {
-        self.len().encode(e);
-        e.extend_from_slice(self);
-    }
-}
-
 impl<T: Encode> Encode for Vec<T> {
     fn encode(&self, e: &mut Vec<u8>) {
         <[T]>::encode(self, e)
@@ -133,6 +126,12 @@ impl Encode for usize {
     fn encode(&self, e: &mut Vec<u8>) {
         assert!(*self <= u32::max_value() as usize);
         (*self as u32).encode(e)
+    }
+}
+
+impl Encode for u8 {
+    fn encode(&self, e: &mut Vec<u8>) {
+        e.push(*self);
     }
 }
 
@@ -668,8 +667,7 @@ impl Encode for V128Const {
 
 impl Encode for V8x16Shuffle {
     fn encode(&self, dst: &mut Vec<u8>) {
-        let indexes: Vec<u8> = self.lanes.iter().map(|&i| i as u8).collect();
-        dst.extend_from_slice(&indexes);
+        dst.extend_from_slice(&self.lanes);
     }
 }
 

--- a/tests/wabt.rs
+++ b/tests/wabt.rs
@@ -130,7 +130,7 @@ fn test_wast(test: &Path, contents: &str) -> anyhow::Result<()> {
                     module: QuoteModule::Quote(source),
                     message,
                 } => {
-                    let source = source.concat();
+                    let source = source.join(" ");
                     let result = ParseBuffer::new(&source)
                         .map_err(|e| e.into())
                         .and_then(|b| -> Result<(), wast::Error> {
@@ -201,11 +201,17 @@ fn error_matches(error: &str, message: &str) -> bool {
     if message == "unknown operator"
         || message == "unexpected token"
         || message == "wrong number of lane literals"
+        || message == "type mismatch"
+        || message == "malformed lane index"
+        || message == "expected i8 literal"
+        || message == "invalid lane length"
+        || message == "alignment must be a power of two"
     {
         return error.contains("expected a ")
             || error.contains("expected an ")
             || error.contains("constant out of range");
     }
+
     return false;
 }
 
@@ -426,6 +432,15 @@ fn skip_test(test: &Path, contents: &str) -> bool {
     // Like above this uses `iNNxMM.load_splat` but the simd spec doesn't have
     // these and the test seems to disagree at least a bit on encoding.
     if test.ends_with("logging-all-opcodes.txt") {
+        return true;
+    }
+
+    // These all use now-removed simd instructions, so we're waiting for wabt to
+    // update to the latest simd spec
+    if test.ends_with("tracing-all-opcodes.txt")
+        || test.ends_with("simd-unary.txt")
+        || test.ends_with("simd/simd_conversions.wast")
+    {
         return true;
     }
 


### PR DESCRIPTION
With these tweaks as well as some tweaks to the simd spec test suite
we're now at the point where we're parsing all the upstream simd
`*.wast` files and passing all the tests that we can with this
implementation, yay!