### PR TITLE
Allow specifying table indices for `table.copy`

### DIFF
--- a/crates/wast/src/ast/expr.rs
+++ b/crates/wast/src/ast/expr.rs
@@ -398,7 +398,7 @@ instructions! {
         DataDrop(ast::Index<'a>) : [0xfc, 0x09] : "data.drop",
         ElemDrop(ast::Index<'a>) : [0xfc, 0x0d] : "elem.drop",
         TableInit(TableInit<'a>) : [0xfc, 0x0c] : "table.init",
-        TableCopy : [0xfc, 0x0e, 0x00, 0x00] : "table.copy",
+        TableCopy(TableCopy<'a>) : [0xfc, 0x0e] : "table.copy",
         TableFill(ast::Index<'a>) : [0xfc, 0x11] : "table.fill",
         TableSize(ast::Index<'a>) : [0xfc, 0x10] : "table.size",
         TableGrow(ast::Index<'a>) : [0xfc, 0x0f] : "table.grow",
@@ -966,6 +966,26 @@ impl<'a> Parse<'a> for TableInit<'a> {
         Ok(TableInit {
             elem: parser.parse()?,
         })
+    }
+}
+
+/// Extra data associated with the `table.copy` instruction.
+#[derive(Debug)]
+pub struct TableCopy<'a> {
+    /// The index of the destination table to copy into.
+    pub dst: ast::Index<'a>,
+    /// The index of the source table to copy from.
+    pub src: ast::Index<'a>,
+}
+
+impl<'a> Parse<'a> for TableCopy<'a> {
+    fn parse(parser: Parser<'a>) -> Result<Self> {
+        let (dst, src) = if let Some(dst) = parser.parse()? {
+            (dst, parser.parse()?)
+        } else {
+            (ast::Index::Num(0), ast::Index::Num(0))
+        };
+        Ok(TableCopy { dst, src })
     }
 }
 

--- a/crates/wast/src/binary.rs
+++ b/crates/wast/src/binary.rs
@@ -535,6 +535,13 @@ impl Encode for TableInit<'_> {
     }
 }
 
+impl Encode for TableCopy<'_> {
+    fn encode(&self, e: &mut Vec<u8>) {
+        self.dst.encode(e);
+        self.src.encode(e);
+    }
+}
+
 impl Encode for MemoryInit<'_> {
     fn encode(&self, e: &mut Vec<u8>) {
         // TODO: this agrees with `wabt` but disagrees with the current online

--- a/crates/wast/src/resolve/names.rs
+++ b/crates/wast/src/resolve/names.rs
@@ -276,6 +276,11 @@ impl<'a, 'b> ExprResolver<'a, 'b> {
             TableInit(i) => self.resolver.resolve_idx(&mut i.elem, Ns::Elem),
             ElemDrop(i) => self.resolver.resolve_idx(i, Ns::Elem),
 
+            TableCopy(i) => {
+                self.resolver.resolve_idx(&mut i.dst, Ns::Table)?;
+                self.resolver.resolve_idx(&mut i.src, Ns::Table)
+            }
+
             TableFill(i) | TableSet(i) | TableGet(i) | TableSize(i) | TableGrow(i) => {
                 self.resolver.resolve_idx(i, Ns::Table)
             }

--- a/tests/regression/table-copy.wat
+++ b/tests/regression/table-copy.wat
@@ -1,0 +1,22 @@
+(module $n
+  (table $t (import "m" "t") 6 funcref)
+
+  (func $i (param i32 i32 i32 i32 i32 i32) (result i32) (local.get 3))
+  (func $j (param i32 i32 i32 i32 i32 i32) (result i32) (local.get 4))
+  (func $k (param i32 i32 i32 i32 i32 i32) (result i32) (local.get 5))
+
+  (table $u (export "u") funcref (elem $i $j $k $i $j $k))
+
+  (func (export "copy_t_u") (param i32 i32 i32 i32) (result i32)
+    local.get 0
+    local.get 1
+    local.get 2
+    local.get 3
+    table.copy $t $u)
+
+  (func (export "copy_u_t") (param i32 i32 i32 i32) (result i32)
+    local.get 0
+    local.get 1
+    local.get 2
+    local.get 3
+    table.copy $u $t))


### PR DESCRIPTION
This is WIP specified in the reference types proposal. For example, it's in the
text format and execution text, but not the binary encoding or validation text.