### PR TITLE
doc(ast) Fix an intra link near `Module::resolve`

### DIFF
--- a/crates/wast/src/ast/module.rs
+++ b/crates/wast/src/ast/module.rs
@@ -121,7 +121,7 @@ impl<'a> Module<'a> {
             }
         }
         if starts > 1 {
-            return Err(parser.error("multiple start sections found"))
+            return Err(parser.error("multiple start sections found"));
         }
         Ok(())
     }

--- a/crates/wast/src/ast/module.rs
+++ b/crates/wast/src/ast/module.rs
@@ -66,7 +66,7 @@ impl<'a> Module<'a> {
     /// where expansion and name resolution happens.
     ///
     /// This function will mutate the AST of this [`Module`] and replace all
-    /// [`Index`] arguments with `Index::Num`. This will also expand inline
+    /// [`super::Index`] arguments with `Index::Num`. This will also expand inline
     /// exports/imports listed on fields and handle various other shorthands of
     /// the text format.
     ///

--- a/crates/wast/src/lib.rs
+++ b/crates/wast/src/lib.rs
@@ -45,7 +45,7 @@
 //! [`Parse`]: parser::Parse
 //! [`LexError`]: lexer::LexError
 
-#![deny(missing_docs)]
+#![deny(missing_docs, intra_doc_link_resolution_failure)]
 
 use std::fmt;
 use std::path::{Path, PathBuf};


### PR DESCRIPTION
This patch does 2 things:

1. Fix an intra link in the doc',
2. Deny intra link failure.