### PR TITLE
Support parsing multi-table `table.init` instruction

### DIFF
--- a/crates/wast/src/ast/expr.rs
+++ b/crates/wast/src/ast/expr.rs
@@ -957,15 +957,20 @@ impl<'a> Parse<'a> for CallIndirect<'a> {
 /// Extra data associated with the `table.init` instruction
 #[derive(Debug)]
 pub struct TableInit<'a> {
+    /// The index of the table we're copying into.
+    pub table: ast::Index<'a>,
     /// The index of the element segment we're copying into a table.
     pub elem: ast::Index<'a>,
 }
 
 impl<'a> Parse<'a> for TableInit<'a> {
     fn parse(parser: Parser<'a>) -> Result<Self> {
-        Ok(TableInit {
-            elem: parser.parse()?,
-        })
+        let table_or_elem = parser.parse()?;
+        let (table, elem) = match parser.parse()? {
+            Some(elem) => (table_or_elem, elem),
+            None => (ast::Index::Num(0), table_or_elem),
+        };
+        Ok(TableInit { table, elem })
     }
 }
 

--- a/crates/wast/src/binary.rs
+++ b/crates/wast/src/binary.rs
@@ -531,7 +531,7 @@ impl Encode for TableInit<'_> {
         // spec. Online spec says `0x00` comes before elem segment, wabt says
         // otherwise. Let's match `wabt` for now.
         self.elem.encode(e);
-        e.push(0x00);
+        self.table.encode(e);
     }
 }
 

--- a/crates/wast/src/resolve/names.rs
+++ b/crates/wast/src/resolve/names.rs
@@ -273,7 +273,10 @@ impl<'a, 'b> ExprResolver<'a, 'b> {
             MemoryInit(i) => self.resolver.resolve_idx(&mut i.data, Ns::Data),
             DataDrop(i) => self.resolver.resolve_idx(i, Ns::Data),
 
-            TableInit(i) => self.resolver.resolve_idx(&mut i.elem, Ns::Elem),
+            TableInit(i) => {
+                self.resolver.resolve_idx(&mut i.elem, Ns::Elem)?;
+                self.resolver.resolve_idx(&mut i.table, Ns::Table)
+            }
             ElemDrop(i) => self.resolver.resolve_idx(i, Ns::Elem),
 
             TableCopy(i) => {

--- a/tests/regression/table-init.wat
+++ b/tests/regression/table-init.wat
@@ -1,0 +1,4 @@
+(module
+  (table $t1 1 1 funcref)
+  (func table.init $t1 $e)
+  (elem $e func 0))


### PR DESCRIPTION
With multiple tables you need to be able to specify which table is being
initialized! This supports the now-legacy "only specify the element
segment" index by assuming table 0 if not specified.