### PR TITLE
Disallow duplicate identifiers

### DIFF
--- a/crates/wast/src/resolve/mod.rs
+++ b/crates/wast/src/resolve/mod.rs
@@ -71,7 +71,7 @@ pub fn resolve<'a>(module: &mut Module<'a>) -> Result<Names<'a>, Error> {
     move_imports_first(fields);
     let mut resolver = names::Resolver::default();
     for field in fields.iter_mut() {
-        resolver.register(field);
+        resolver.register(field)?;
     }
     for field in fields.iter_mut() {
         resolver.resolve(field)?;

--- a/tests/regression/duplicate.wast
+++ b/tests/regression/duplicate.wast
@@ -1,0 +1,58 @@
+(assert_malformed (module quote
+  "(func $foo)"
+  "(func $foo)")
+  "duplicate identifier")
+(assert_malformed (module quote
+  "(import \"\" \"\" (func $foo))"
+  "(func $foo)")
+  "duplicate identifier")
+(assert_malformed (module quote
+  "(import \"\" \"\" (func $foo))"
+  "(import \"\" \"\" (func $foo))")
+  "duplicate identifier")
+
+(assert_malformed (module quote
+  "(global $foo i32 (i32.const 0))"
+  "(global $foo i32 (i32.const 0))")
+  "duplicate identifier")
+(assert_malformed (module quote
+  "(import \"\" \"\" (global $foo i32))"
+  "(global $foo i32 (i32.const 0))")
+  "duplicate identifier")
+(assert_malformed (module quote
+  "(import \"\" \"\" (global $foo i32))"
+  "(import \"\" \"\" (global $foo i32))")
+  "duplicate identifier")
+
+(assert_malformed (module quote
+  "(memory $foo 1)"
+  "(memory $foo 1)")
+  "duplicate identifier")
+(assert_malformed (module quote
+  "(import \"\" \"\" (memory $foo 1))"
+  "(memory $foo 1)")
+  "duplicate identifier")
+(assert_malformed (module quote
+  "(import \"\" \"\" (memory $foo 1))"
+  "(import \"\" \"\" (memory $foo 1))")
+  "duplicate identifier")
+
+(assert_malformed (module quote
+  "(table $foo 1 funcref)"
+  "(table $foo 1 funcref)")
+  "duplicate identifier")
+(assert_malformed (module quote
+  "(import \"\" \"\" (table $foo 1 funcref))"
+  "(table $foo 1 funcref)")
+  "duplicate identifier")
+(assert_malformed (module quote
+  "(import \"\" \"\" (table $foo 1 funcref))"
+  "(import \"\" \"\" (table $foo 1 funcref))")
+  "duplicate identifier")
+
+(assert_malformed (module quote "(func (param $foo i32) (param $foo i32))")
+  "duplicate identifier")
+(assert_malformed (module quote "(func (param $foo i32) (local $foo i32))")
+  "duplicate identifier")
+(assert_malformed (module quote "(func (local $foo i32) (local $foo i32))")
+  "duplicate identifier")


### PR DESCRIPTION
Temporarily allow elem/data segments to have duplicate identifiers due
to unfortunate artifacts of how the official test suite is organized,
but otherwise relatively straightforward!

Closes #60