### PR TITLE
Implement the GC proposal

### DIFF
--- a/crates/wast/src/ast/func.rs
+++ b/crates/wast/src/ast/func.rs
@@ -43,7 +43,7 @@ pub enum FuncKind<'a> {
         /// The list of locals, if any, for this function. Each local has an
         /// optional identifier for name resolution and name for the custom
         /// `name` section associated with it.
-        locals: Vec<(Option<ast::Id<'a>>, Option<ast::NameAnnotation<'a>>, ast::ValType)>,
+        locals: Vec<(Option<ast::Id<'a>>, Option<ast::NameAnnotation<'a>>, ast::ValType<'a>)>,
 
         /// The instructions of the function.
         expression: ast::Expression<'a>,

--- a/crates/wast/src/ast/gc.rs
+++ b/crates/wast/src/ast/gc.rs
@@ -1,0 +1,22 @@
+use crate::ast::{self, kw};
+use crate::parser::{Parse, Parser, Result};
+
+/// A WebAssembly GC opt-in directive, part of the GC prototype.
+#[derive(Debug)]
+pub struct GcOptIn {
+    /// Where this event was defined
+    pub span: ast::Span,
+    /// The version of the GC proposal
+    pub version: u8,
+}
+
+impl<'a> Parse<'a> for GcOptIn {
+    fn parse(parser: Parser<'a>) -> Result<Self> {
+        let span = parser.parse::<kw::gc_feature_opt_in>()?.0;
+        let version = parser.parse()?;
+        Ok(GcOptIn {
+            span,
+            version,
+        })
+    }
+}

--- a/crates/wast/src/ast/global.rs
+++ b/crates/wast/src/ast/global.rs
@@ -12,7 +12,7 @@ pub struct Global<'a> {
     /// definition should be exported under.
     pub exports: ast::InlineExport<'a>,
     /// The type of this global, both its value type and whether it's mutable.
-    pub ty: ast::GlobalType,
+    pub ty: ast::GlobalType<'a>,
     /// What kind of global this defined as.
     pub kind: GlobalKind<'a>,
 }

--- a/crates/wast/src/ast/import.rs
+++ b/crates/wast/src/ast/import.rs
@@ -27,7 +27,7 @@ pub enum ImportKind<'a> {
     Func(ast::TypeUse<'a>),
     Table(ast::TableType),
     Memory(ast::MemoryType),
-    Global(ast::GlobalType),
+    Global(ast::GlobalType<'a>),
     Event(ast::EventType<'a>),
 }
 

--- a/crates/wast/src/ast/mod.rs
+++ b/crates/wast/src/ast/mod.rs
@@ -240,6 +240,7 @@ reexport! {
     mod export;
     mod expr;
     mod func;
+    mod gc;
     mod global;
     mod import;
     mod memory;
@@ -284,6 +285,7 @@ pub mod kw {
     custom_keyword!(first);
     custom_keyword!(func);
     custom_keyword!(funcref);
+    custom_keyword!(gc_feature_opt_in);
     custom_keyword!(get);
     custom_keyword!(global);
     custom_keyword!(i16x8);

--- a/crates/wast/src/ast/mod.rs
+++ b/crates/wast/src/ast/mod.rs
@@ -282,6 +282,7 @@ pub mod kw {
     custom_keyword!(f32x4);
     custom_keyword!(f64);
     custom_keyword!(f64x2);
+    custom_keyword!(field);
     custom_keyword!(first);
     custom_keyword!(func);
     custom_keyword!(funcref);
@@ -313,12 +314,14 @@ pub mod kw {
     custom_keyword!(r#loop = "loop");
     custom_keyword!(r#mut = "mut");
     custom_keyword!(r#type = "type");
+    custom_keyword!(r#ref = "ref");
     custom_keyword!(ref_func = "ref.func");
     custom_keyword!(ref_null = "ref.null");
     custom_keyword!(register);
     custom_keyword!(result);
     custom_keyword!(shared);
     custom_keyword!(start);
+    custom_keyword!(r#struct = "struct");
     custom_keyword!(table);
     custom_keyword!(then);
     custom_keyword!(v128);

--- a/crates/wast/src/ast/module.rs
+++ b/crates/wast/src/ast/module.rs
@@ -170,6 +170,7 @@ pub enum ModuleField<'a> {
     Elem(ast::Elem<'a>),
     Data(ast::Data<'a>),
     Event(ast::Event<'a>),
+    GcOptIn(ast::GcOptIn),
     Custom(ast::Custom<'a>),
 }
 
@@ -218,6 +219,9 @@ impl<'a> Parse<'a> for ModuleField<'a> {
         }
         if parser.peek::<kw::event>() {
             return Ok(ModuleField::Event(parser.parse()?));
+        }
+        if parser.peek::<kw::gc_feature_opt_in>() {
+            return Ok(ModuleField::GcOptIn(parser.parse()?));
         }
         if parser.peek::<annotation::custom>() {
             return Ok(ModuleField::Custom(parser.parse()?));

--- a/crates/wast/src/ast/token.rs
+++ b/crates/wast/src/ast/token.rs
@@ -111,7 +111,7 @@ impl Peek for Id<'_> {
 ///
 /// The emission phase of a module will ensure that `Index::Id` is never used
 /// and switch them all to `Index::Num`.
-#[derive(Copy, Clone, PartialEq, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
 pub enum Index<'a> {
     /// A numerical index that this references. The index space this is
     /// referencing is implicit based on where this [`Index`] is stored.

--- a/crates/wast/src/resolve/names.rs
+++ b/crates/wast/src/resolve/names.rs
@@ -72,9 +72,10 @@ impl<'a> Resolver<'a> {
             ModuleField::Elem(e) => register(Ns::Elem, e.id),
             ModuleField::Data(d) => register(Ns::Data, d.id),
             ModuleField::Event(e) => register(Ns::Event, e.id),
-            ModuleField::Start(_) => Ok(()),
-            ModuleField::Export(_) => Ok(()),
-            ModuleField::Custom(_) => Ok(()),
+            ModuleField::Start(_)
+            | ModuleField::Export(_)
+            | ModuleField::GcOptIn(_)
+            | ModuleField::Custom(_) => Ok(()),
         }
     }
 

--- a/crates/wast/src/resolve/names.rs
+++ b/crates/wast/src/resolve/names.rs
@@ -12,6 +12,7 @@ pub enum Ns {
     Memory,
     Table,
     Type,
+    Field,
 }
 
 impl Ns {
@@ -25,19 +26,15 @@ impl Ns {
             Ns::Memory => "memory",
             Ns::Table => "table",
             Ns::Type => "type",
+            Ns::Field => "field",
         }
     }
 }
 
 #[derive(Default)]
 pub struct Resolver<'a> {
-    ns: [Namespace<'a>; 8],
-    tys: Vec<Type<'a>>,
-}
-
-struct Type<'a> {
-    params: Vec<(Option<Id<'a>>, Option<NameAnnotation<'a>>, ValType)>,
-    results: Vec<ValType>,
+    ns: [Namespace<'a>; 9],
+    func_tys: HashMap<u32, FunctionType<'a>>,
 }
 
 #[derive(Default)]
@@ -48,7 +45,8 @@ struct Namespace<'a> {
 
 impl<'a> Resolver<'a> {
     pub fn register(&mut self, item: &ModuleField<'a>) -> Result<(), Error> {
-        let mut register = |ns: Ns, name: Option<Id<'a>>| self.ns_mut(ns).register(name, ns.desc());
+        let mut register =
+            |ns: Ns, name: Option<Id<'a>>| self.ns_mut(ns).register(name, ns.desc()).map(|_| ());
         match item {
             ModuleField::Import(i) => match i.kind {
                 ImportKind::Func(_) => register(Ns::Func, i.id),
@@ -62,11 +60,30 @@ impl<'a> Resolver<'a> {
             ModuleField::Func(i) => register(Ns::Func, i.id),
             ModuleField::Table(i) => register(Ns::Table, i.id),
             ModuleField::Type(i) => {
-                register(Ns::Type, i.id)?;
-                self.tys.push(Type {
-                    params: i.func.params.clone(),
-                    results: i.func.results.clone(),
-                });
+                let index = self.ns_mut(Ns::Type).register(i.id, Ns::Type.desc())?;
+                match &i.def {
+                    TypeDef::Func(func) => {
+                        // Store a copy of this function type for resolving
+                        // type uses later. We can't resolve this copy yet, so
+                        // we will take care of that when resolving the type
+                        // use.
+                        self.func_tys.insert(index, func.clone());
+                    }
+                    TypeDef::Struct(r#struct) => {
+                        for (i, field) in r#struct.fields.iter().enumerate() {
+                            if let Some(id) = field.id {
+                                // The field namespace is global, but the
+                                // resolved indices are relative to the struct
+                                // they are defined in
+                                self.ns_mut(Ns::Field).register_specific(
+                                    id,
+                                    i as u32,
+                                    Ns::Field.desc(),
+                                )?;
+                            }
+                        }
+                    }
+                }
                 Ok(())
             }
             ModuleField::Elem(e) => register(Ns::Elem, e.id),
@@ -99,13 +116,22 @@ impl<'a> Resolver<'a> {
                 Ok(())
             }
 
+            ModuleField::Type(t) => self.resolve_type(t),
+
             ModuleField::Func(f) => {
                 self.resolve_type_use(f.span, &mut f.ty)?;
                 if let FuncKind::Inline { locals, expression } = &mut f.kind {
+                    // Resolve (ref T) in locals
+                    for (_, _, valtype) in locals.iter_mut() {
+                        self.resolve_valtype(valtype)?;
+                    }
+
+                    // Build a resolver with local namespace for the function
+                    // body
                     let mut resolver = ExprResolver::new(self, f.span);
 
                     // Parameters come first in the local namespace...
-                    for (id, _, _) in f.ty.ty.params.iter() {
+                    for (id, _, _) in f.ty.func_ty.params.iter() {
                         resolver.locals.register(*id, "local")?;
                     }
 
@@ -167,6 +193,7 @@ impl<'a> Resolver<'a> {
             },
 
             ModuleField::Global(g) => {
+                self.resolve_valtype(&mut g.ty.ty)?;
                 if let GlobalKind::Inline(expr) = &mut g.kind {
                     self.resolve_expr(g.span, expr)?;
                 }
@@ -177,9 +204,42 @@ impl<'a> Resolver<'a> {
 
             ModuleField::Table(_)
             | ModuleField::Memory(_)
-            | ModuleField::Type(_)
+            | ModuleField::GcOptIn(_)
             | ModuleField::Custom(_) => Ok(()),
         }
+    }
+
+    fn resolve_valtype(&self, ty: &mut ValType<'a>) -> Result<(), Error> {
+        if let ValType::Ref(id) = ty {
+            self.ns(Ns::Type)
+                .resolve(id)
+                .map_err(|id| self.resolve_error(id, "type"))?;
+        }
+        Ok(())
+    }
+
+    fn resolve_type(&self, ty: &mut Type<'a>) -> Result<(), Error> {
+        match &mut ty.def {
+            TypeDef::Func(func) => self.resolve_function_type(func),
+            TypeDef::Struct(r#struct) => self.resolve_struct_type(r#struct),
+        }
+    }
+
+    fn resolve_function_type(&self, func: &mut FunctionType<'a>) -> Result<(), Error> {
+        for param in &mut func.params {
+            self.resolve_valtype(&mut param.2)?;
+        }
+        for result in &mut func.results {
+            self.resolve_valtype(result)?;
+        }
+        Ok(())
+    }
+
+    fn resolve_struct_type(&self, r#struct: &mut StructType<'a>) -> Result<(), Error> {
+        for field in &mut r#struct.fields {
+            self.resolve_valtype(&mut field.ty)?;
+        }
+        Ok(())
     }
 
     fn resolve_type_use(&self, span: Span, ty: &mut TypeUse<'a>) -> Result<u32, Error> {
@@ -191,17 +251,20 @@ impl<'a> Resolver<'a> {
 
         // If the type was listed inline *and* it was specified via a type index
         // we need to assert they're the same.
-        let expected = match self.tys.get(idx as usize) {
+        let expected = match self.func_tys.get(&(idx as u32)) {
             Some(ty) => ty,
             None => return Ok(idx),
         };
-        if ty.ty.params.len() > 0 || ty.ty.results.len() > 0 {
+        if ty.func_ty.params.len() > 0 || ty.func_ty.results.len() > 0 {
+            // The function type for this type use hasn't been resolved,
+            // but neither has the expected function type, so this comparison
+            // is valid.
             let params_not_equal = expected.params.iter().map(|t| t.2).ne(ty
-                .ty
+                .func_ty
                 .params
                 .iter()
                 .map(|t| t.2));
-            if params_not_equal || expected.results != ty.ty.results {
+            if params_not_equal || expected.results != ty.func_ty.results {
                 let span = ty.index_span.unwrap_or(span);
                 return Err(Error::new(
                     span,
@@ -209,9 +272,12 @@ impl<'a> Resolver<'a> {
                 ));
             }
         } else {
-            ty.ty.params = expected.params.clone();
-            ty.ty.results = expected.results.clone();
+            ty.func_ty.params = expected.params.clone();
+            ty.func_ty.results = expected.results.clone();
         }
+
+        // Resolve the (ref T) value types in the final function type
+        self.resolve_function_type(&mut ty.func_ty)?;
 
         Ok(idx)
     }
@@ -245,9 +311,10 @@ impl<'a> Resolver<'a> {
 }
 
 impl<'a> Namespace<'a> {
-    fn register(&mut self, name: Option<Id<'a>>, desc: &str) -> Result<(), Error> {
+    fn register(&mut self, name: Option<Id<'a>>, desc: &str) -> Result<u32, Error> {
+        let index = self.count;
         if let Some(name) = name {
-            if let Some(_prev) = self.names.insert(name, self.count) {
+            if let Some(_prev) = self.names.insert(name, index) {
                 // FIXME: temporarily allow duplicately-named data and element
                 // segments. This is a sort of dumb hack to get the spec test
                 // suite working (ironically).
@@ -277,6 +344,16 @@ impl<'a> Namespace<'a> {
             }
         }
         self.count += 1;
+        Ok(index)
+    }
+
+    fn register_specific(&mut self, name: Id<'a>, index: u32, desc: &str) -> Result<(), Error> {
+        if let Some(_prev) = self.names.insert(name, index) {
+            return Err(Error::new(
+                name.span(),
+                format!("duplicate identifier for {}", desc),
+            ));
+        }
         Ok(())
     }
 
@@ -385,16 +462,20 @@ impl<'a, 'b> ExprResolver<'a, 'b> {
                 // happens.
                 if bt.ty.index.is_some() {
                     let ty = self.resolver.resolve_type_use(self.span, &mut bt.ty)?;
-                    let ty = match self.resolver.tys.get(ty as usize) {
+                    let ty = match self.resolver.func_tys.get(&(ty as u32)) {
                         Some(ty) => ty,
                         None => return Ok(()),
                     };
                     if ty.params.len() == 0 && ty.results.len() <= 1 {
-                        bt.ty.ty.params.truncate(0);
-                        bt.ty.ty.results = ty.results.clone();
+                        bt.ty.func_ty.params.truncate(0);
+                        bt.ty.func_ty.results = ty.results.clone();
                         bt.ty.index = None;
                     }
                 }
+
+                // Resolve (ref T) params and results
+                self.resolver.resolve_function_type(&mut bt.ty.func_ty)?;
+
                 Ok(())
             }
 
@@ -437,6 +518,23 @@ impl<'a, 'b> ExprResolver<'a, 'b> {
             BrOnExn(b) => {
                 self.resolve_label(&mut b.label)?;
                 self.resolver.resolve_idx(&mut b.exn, Ns::Event)
+            }
+
+            Select(s) => {
+                for ty in &mut s.tys {
+                    self.resolver.resolve_valtype(ty)?;
+                }
+                Ok(())
+            }
+
+            StructNew(s) => self.resolver.resolve_idx(s, Ns::Type),
+            StructSet(s) | StructGet(s) => {
+                self.resolver.resolve_idx(&mut s.r#struct, Ns::Type)?;
+                self.resolver.resolve_idx(&mut s.field, Ns::Field)
+            }
+            StructNarrow(s) => {
+                self.resolver.resolve_valtype(&mut s.from)?;
+                self.resolver.resolve_valtype(&mut s.to)
             }
 
             _ => Ok(()),

--- a/tests/regression/gc-ref.wat
+++ b/tests/regression/gc-ref.wat
@@ -1,0 +1,34 @@
+(module
+  (type $a (struct))
+  (type $b (struct))
+
+  (type $f1 (func (param (ref $a))))
+  (type $f2 (func (result (ref $b))))
+
+  (global (ref $a))
+  (global (ref $b))
+
+  (func (param (ref $a)))
+  (func (result (ref $a)))
+  (func (local (ref $a)))
+
+  (func
+    struct.narrow (ref $a) (ref $b)
+    select (result (ref $a))
+
+    (block (param (ref $a)))
+    (block (result (ref $b)))
+    (block $f1 (param (ref $a)))
+    (block $f2 (result (ref $b)))
+
+    (loop (param (ref $a)))
+    (loop (result (ref $b)))
+    (loop $f1 (param (ref $a)))
+    (loop $f2 (result (ref $b)))
+
+    (if (param (ref $a)) (then) (else))
+    (if (result (ref $b)) (then) (else))
+    (if $f1 (param (ref $a)) (then) (else))
+    (if $f2 (result (ref $b)) (then) (else))
+  )
+)

--- a/tests/regression/gc-struct.wat
+++ b/tests/regression/gc-struct.wat
@@ -1,0 +1,26 @@
+(module
+  (type (struct))
+  (type (struct (field i32)))
+  (type (struct (field (mut i32))))
+  (type (struct (field i32) (field i32)))
+  (type (struct (field i32) (field (mut i32))))
+  (type (struct (field (mut i32)) (field (mut i32))))
+
+  (type $a (struct (field f32)))
+  (type $b (struct (field f32)))
+
+  (type (struct (field $field_a anyref)))
+  (type (struct (field $field_b anyref) (field $field_c funcref)))
+
+  (func
+    struct.new $a
+    struct.get $a $field_a
+    struct.set $b $field_c
+  )
+
+  (func
+    struct.narrow i32 f32
+    struct.narrow anyref funcref
+    struct.narrow anyref nullref
+  )
+)


### PR DESCRIPTION
Fixes #64. This implements the version of the GC proposal that exists in SpiderMonkey. Documentation can be found [here](https://github.com/lars-t-hansen/moz-gc-experiments/blob/master/version2.md).

I've been testing this with SpiderMonkey's existing GC testsuite, but also added some basic parse-only tests so that CI will have some coverage here.