### PR TITLE
Exclude 'tests/testsuite'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/wat"
 description = """
 Rust parser for the WebAssembly Text format, WAT
 """
-exclude = ['tests/wabt']
+exclude = ['tests/wabt', 'tests/testsuite']
 
 [workspace]
 members = ['fuzz']


### PR DESCRIPTION
There are several files in testsuite that are above the hardcoded filesize limit for `./mach vendor rust` to be able to import `wat` into Gecko. It looks like excluding them fixes this.