### PR TITLE
More traits for span

### DIFF
--- a/crates/wast/src/ast/token.rs
+++ b/crates/wast/src/ast/token.rs
@@ -1,9 +1,9 @@
+use crate::ast::annotation;
 use crate::lexer::FloatVal;
 use crate::parser::{Cursor, Parse, Parser, Peek, Result};
 use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::str;
-use crate::ast::annotation;
 
 /// A position in the original source stream, used to render errors.
 #[derive(Copy, Clone, Debug, PartialOrd, Ord, PartialEq, Eq, Hash)]

--- a/crates/wast/src/ast/token.rs
+++ b/crates/wast/src/ast/token.rs
@@ -6,7 +6,7 @@ use std::str;
 use crate::ast::annotation;
 
 /// A position in the original source stream, used to render errors.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialOrd, Ord, PartialEq, Eq, Hash)]
 pub struct Span {
     pub(crate) offset: usize,
 }


### PR DESCRIPTION
It is useful to sort a bunch of errors by their span, and it is also nice to use
spans as keys in a hash map.
