### PR TITLE
Add support for exnref type syntax.

### DIFF
--- a/crates/wast/src/ast/mod.rs
+++ b/crates/wast/src/ast/mod.rs
@@ -344,6 +344,7 @@ pub mod kw {
     custom_keyword!(elem);
     custom_keyword!(end);
     custom_keyword!(event);
+    custom_keyword!(exnref);
     custom_keyword!(export);
     custom_keyword!(f32);
     custom_keyword!(f32x4);

--- a/crates/wast/src/ast/types.rs
+++ b/crates/wast/src/ast/types.rs
@@ -13,6 +13,7 @@ pub enum ValType<'a> {
     Funcref,
     V128,
     Nullref,
+    Exnref,
     Ref(ast::Index<'a>)
 }
 
@@ -43,6 +44,9 @@ impl<'a> Parse<'a> for ValType<'a> {
         } else if l.peek::<kw::nullref>() {
             parser.parse::<kw::nullref>()?;
             Ok(ValType::Nullref)
+        } else if l.peek::<kw::exnref>() {
+            parser.parse::<kw::exnref>()?;
+            Ok(ValType::Exnref)
         } else if l.peek::<kw::v128>() {
             parser.parse::<kw::v128>()?;
             Ok(ValType::V128)
@@ -96,6 +100,8 @@ pub enum TableElemType {
     Anyref,
     /// An element for a table that is a list of `nullref` values.
     Nullref,
+    /// An element for a table that is a list of `exnref` values.
+    Exnref,
 }
 
 impl<'a> Parse<'a> for TableElemType {
@@ -115,6 +121,9 @@ impl<'a> Parse<'a> for TableElemType {
         } else if l.peek::<kw::nullref>() {
             parser.parse::<kw::nullref>()?;
             Ok(TableElemType::Nullref)
+        } else if l.peek::<kw::exnref>() {
+            parser.parse::<kw::exnref>()?;
+            Ok(TableElemType::Exnref)
         } else {
             Err(l.error())
         }
@@ -127,6 +136,7 @@ impl Peek for TableElemType {
             || kw::anyref::peek(cursor)
             || kw::nullref::peek(cursor)
             || /* legacy */ kw::anyfunc::peek(cursor)
+            || kw::exnref::peek(cursor)
     }
     fn display() -> &'static str {
         "table element type"

--- a/crates/wast/src/binary.rs
+++ b/crates/wast/src/binary.rs
@@ -245,6 +245,7 @@ impl<'a> Encode for ValType<'a> {
             ValType::Funcref => e.push(0x70),
             ValType::Anyref => e.push(0x6f),
             ValType::Nullref => e.push(0x6e),
+            ValType::Exnref => e.push(0x68),
             ValType::Ref(index) => {
                 e.push(0x6d);
                 index.encode(e);
@@ -313,6 +314,7 @@ impl Encode for TableElemType {
             TableElemType::Funcref => ValType::Funcref.encode(e),
             TableElemType::Anyref => ValType::Anyref.encode(e),
             TableElemType::Nullref => ValType::Nullref.encode(e),
+            TableElemType::Exnref => ValType::Exnref.encode(e),
         }
     }
 }

--- a/tests/regression/exnref.wat
+++ b/tests/regression/exnref.wat
@@ -1,0 +1,2 @@
+(module $m
+  (func $f (param exnref)))


### PR DESCRIPTION
The [exceptions proposal](https://github.com/WebAssembly/exception-handling/blob/master/proposals/Exceptions.md) includes an `exnref` type constructor which isn't currently supported in wat. This PR adds this type syntax.

Also added a test for it (is `tests/regression` fine for that?).