### PR TITLE
Remove funcref as a subtype of anyref

### DIFF
--- a/crates/wast/src/ast/expr.rs
+++ b/crates/wast/src/ast/expr.rs
@@ -1,4 +1,4 @@
-use crate::ast::{self, kw};
+use crate::ast::{self, kw, RefType};
 use crate::parser::{Parse, Parser, Result};
 use std::mem;
 
@@ -411,8 +411,8 @@ instructions! {
         TableSize(TableArg<'a>) : [0xfc, 0x10] : "table.size",
         TableGrow(TableArg<'a>) : [0xfc, 0x0f] : "table.grow",
 
-        RefNull : [0xd0] : "ref.null",
-        RefIsNull : [0xd1] : "ref.is_null",
+        RefNull(RefType<'a>) : [0xd0] : "ref.null",
+        RefIsNull(RefType<'a>) : [0xd1] : "ref.is_null",
         RefHost(u32) : [0xff] : "ref.host", // only used in test harness
         RefFunc(ast::Index<'a>) : [0xd2] : "ref.func",
 

--- a/crates/wast/src/ast/mod.rs
+++ b/crates/wast/src/ast/mod.rs
@@ -348,6 +348,8 @@ pub mod kw {
     custom_keyword!(exn);
     custom_keyword!(exnref);
     custom_keyword!(export);
+    custom_keyword!(r#extern = "extern");
+    custom_keyword!(externref);
     custom_keyword!(eq);
     custom_keyword!(eqref);
     custom_keyword!(f32);

--- a/crates/wast/src/ast/types.rs
+++ b/crates/wast/src/ast/types.rs
@@ -93,6 +93,16 @@ pub enum RefType<'a> {
     OptType(ast::Index<'a>),
 }
 
+impl<'a> From<TableElemType> for RefType<'a> {
+    fn from(elem: TableElemType) -> Self {
+        match elem {
+            TableElemType::Funcref => RefType::Func,
+            TableElemType::Anyref => RefType::Any,
+            TableElemType::Exnref => RefType::Exn,
+        }
+    }
+}
+
 impl<'a> Parse<'a> for RefType<'a> {
     fn parse(parser: Parser<'a>) -> Result<Self> {
         let mut l = parser.lookahead1();
@@ -151,8 +161,6 @@ impl<'a> Parse<'a> for GlobalType<'a> {
 }
 
 /// List of different kinds of table types we can have.
-///
-/// Currently there's only one, a `funcref`.
 #[derive(Copy, Clone, Debug)]
 pub enum TableElemType {
     /// An element for a table that is a list of functions.

--- a/crates/wast/src/ast/types.rs
+++ b/crates/wast/src/ast/types.rs
@@ -14,7 +14,6 @@ pub enum ValType<'a> {
     I16,
     Funcref,
     Anyref,
-    Nullref,
     Exnref,
     Ref(ast::Index<'a>),
     Optref(ast::Index<'a>),
@@ -56,9 +55,6 @@ impl<'a> Parse<'a> for ValType<'a> {
         } else if l.peek::<kw::anyref>() {
             parser.parse::<kw::anyref>()?;
             Ok(ValType::Anyref)
-        } else if l.peek::<kw::nullref>() {
-            parser.parse::<kw::nullref>()?;
-            Ok(ValType::Nullref)
         } else if l.peek::<ast::LParen>() {
             parser.parens(|p| {
                 let mut l = parser.lookahead1();
@@ -72,9 +68,6 @@ impl<'a> Parse<'a> for ValType<'a> {
                     } else if l.peek::<kw::any>() {
                         parser.parse::<kw::any>()?;
                         Ok(ValType::Anyref)
-                    } else if l.peek::<kw::null>() {
-                        parser.parse::<kw::null>()?;
-                        Ok(ValType::Nullref)
                     } else if l.peek::<kw::exn>() {
                         parser.parse::<kw::exn>()?;
                         Ok(ValType::Exnref)
@@ -154,8 +147,6 @@ pub enum TableElemType {
     Funcref,
     /// An element for a table that is a list of `anyref` values.
     Anyref,
-    /// An element for a table that is a list of `nullref` values.
-    Nullref,
     /// An element for a table that is a list of `exnref` values.
     Exnref,
 }
@@ -174,9 +165,6 @@ impl<'a> Parse<'a> for TableElemType {
         } else if l.peek::<kw::anyref>() {
             parser.parse::<kw::anyref>()?;
             Ok(TableElemType::Anyref)
-        } else if l.peek::<kw::nullref>() {
-            parser.parse::<kw::nullref>()?;
-            Ok(TableElemType::Nullref)
         } else if l.peek::<kw::exnref>() {
             parser.parse::<kw::exnref>()?;
             Ok(TableElemType::Exnref)
@@ -190,7 +178,6 @@ impl Peek for TableElemType {
     fn peek(cursor: Cursor<'_>) -> bool {
         kw::funcref::peek(cursor)
             || kw::anyref::peek(cursor)
-            || kw::nullref::peek(cursor)
             || /* legacy */ kw::anyfunc::peek(cursor)
             || kw::exnref::peek(cursor)
     }

--- a/crates/wast/src/ast/types.rs
+++ b/crates/wast/src/ast/types.rs
@@ -46,8 +46,8 @@ impl<'a> Parse<'a> for ValType<'a> {
         } else if l.peek::<kw::anyfunc>() {
             parser.parse::<kw::anyfunc>()?;
             Ok(ValType::Ref(RefType::Func))
-        } else if l.peek::<kw::r#externref>() {
-            parser.parse::<kw::r#externref>()?;
+        } else if l.peek::<kw::externref>() {
+            parser.parse::<kw::externref>()?;
             Ok(ValType::Ref(RefType::Extern))
         } else if l.peek::<kw::anyref>() {
             // Parse `anyref` as an alias of `externref` until all tests are
@@ -89,12 +89,27 @@ impl<'a> Parse<'a> for ValType<'a> {
 #[allow(missing_docs)]
 #[derive(Debug, PartialEq, Eq, Hash, Copy, Clone)]
 pub enum RefType<'a> {
+    /// An untyped function reference: funcref. This is part of the reference
+    /// types proposal.
     Func,
+    /// A reference to any host value: externref. This was originally known as
+    /// anyref when it was the supertype of all reference value types. This is
+    /// part of the reference types proposal.
     Extern,
+    /// A reference to an exception: exnref. This is part of the exception
+    /// handling proposal.
     Exn,
+    /// A reference that has an identity that can be compared: eqref. This is
+    /// part of the GC proposal.
     Eq,
+    /// An unboxed 31-bit integer: i31ref. This may be going away if there is no common
+    /// supertype of all reference types. Part of the GC proposal.
     I31,
+    /// A reference to a function, struct, or array: ref T. This is part of the
+    /// GC proposal.
     Type(ast::Index<'a>),
+    /// A nullable reference to a function, struct, or array: optref T. This is
+    /// part of the GC proposal.
     OptType(ast::Index<'a>),
 }
 
@@ -116,9 +131,6 @@ impl<'a> Parse<'a> for RefType<'a> {
             Ok(RefType::Func)
         } else if l.peek::<kw::r#extern>() {
             parser.parse::<kw::r#extern>()?;
-            Ok(RefType::Extern)
-        } else if l.peek::<kw::any>() {
-            parser.parse::<kw::any>()?;
             Ok(RefType::Extern)
         } else if l.peek::<kw::exn>() {
             parser.parse::<kw::exn>()?;

--- a/crates/wast/src/binary.rs
+++ b/crates/wast/src/binary.rs
@@ -252,7 +252,6 @@ impl<'a> Encode for ValType<'a> {
             ValType::I16 => e.push(0x79),
             ValType::Funcref => e.push(0x70),
             ValType::Anyref => e.push(0x6f),
-            ValType::Nullref => e.push(0x6e),
             ValType::Ref(index) => {
                 e.push(0x6d);
                 index.encode(e);
@@ -331,7 +330,6 @@ impl Encode for TableElemType {
         match self {
             TableElemType::Funcref => ValType::Funcref.encode(e),
             TableElemType::Anyref => ValType::Anyref.encode(e),
-            TableElemType::Nullref => ValType::Nullref.encode(e),
             TableElemType::Exnref => ValType::Exnref.encode(e),
         }
     }

--- a/crates/wast/src/binary.rs
+++ b/crates/wast/src/binary.rs
@@ -525,7 +525,7 @@ impl Encode for ElemPayload<'_> {
     fn encode(&self, e: &mut Vec<u8>) {
         match self {
             ElemPayload::Indices(v) => v.encode(e),
-            ElemPayload::Exprs { exprs, .. } => {
+            ElemPayload::Exprs { exprs, ty } => {
                 exprs.len().encode(e);
                 for idx in exprs {
                     match idx {
@@ -533,7 +533,7 @@ impl Encode for ElemPayload<'_> {
                             Instruction::RefFunc(*idx).encode(e);
                         }
                         None => {
-                            Instruction::RefNull.encode(e);
+                            Instruction::RefNull((*ty).into()).encode(e);
                         }
                     }
                     Instruction::End(None).encode(e);

--- a/crates/wast/src/binary.rs
+++ b/crates/wast/src/binary.rs
@@ -250,23 +250,33 @@ impl<'a> Encode for ValType<'a> {
             ValType::V128 => e.push(0x7b),
             ValType::I8 => e.push(0x7a),
             ValType::I16 => e.push(0x79),
-            ValType::Funcref => e.push(0x70),
-            ValType::Anyref => e.push(0x6f),
-            ValType::Ref(index) => {
-                e.push(0x6d);
-                index.encode(e);
+            ValType::Ref(ty) => {
+                ty.encode(e);
             }
-            ValType::Optref(index) => {
-                e.push(0x6c);
-                index.encode(e);
-            }
-            ValType::Eqref => e.push(0x6b),
-            ValType::I31ref => e.push(0x6a),
             ValType::Rtt(index) => {
                 e.push(0x69);
                 index.encode(e);
             }
-            ValType::Exnref => e.push(0x68),
+        }
+    }
+}
+
+impl<'a> Encode for RefType<'a> {
+    fn encode(&self, e: &mut Vec<u8>) {
+        match self {
+            RefType::Func => e.push(0x70),
+            RefType::Any => e.push(0x6f),
+            RefType::Eq => e.push(0x6b),
+            RefType::I31 => e.push(0x6a),
+            RefType::Exn => e.push(0x68),
+            RefType::Type(index) => {
+                e.push(0x6d);
+                index.encode(e);
+            }
+            RefType::OptType(index) => {
+                e.push(0x6c);
+                index.encode(e);
+            }
         }
     }
 }
@@ -328,9 +338,9 @@ impl Encode for TableType {
 impl Encode for TableElemType {
     fn encode(&self, e: &mut Vec<u8>) {
         match self {
-            TableElemType::Funcref => ValType::Funcref.encode(e),
-            TableElemType::Anyref => ValType::Anyref.encode(e),
-            TableElemType::Exnref => ValType::Exnref.encode(e),
+            TableElemType::Funcref => RefType::Func.encode(e),
+            TableElemType::Anyref => RefType::Any.encode(e),
+            TableElemType::Exnref => RefType::Exn.encode(e),
         }
     }
 }

--- a/crates/wast/src/binary.rs
+++ b/crates/wast/src/binary.rs
@@ -265,7 +265,7 @@ impl<'a> Encode for RefType<'a> {
     fn encode(&self, e: &mut Vec<u8>) {
         match self {
             RefType::Func => e.push(0x70),
-            RefType::Any => e.push(0x6f),
+            RefType::Extern => e.push(0x6f),
             RefType::Eq => e.push(0x6b),
             RefType::I31 => e.push(0x6a),
             RefType::Exn => e.push(0x68),
@@ -339,7 +339,7 @@ impl Encode for TableElemType {
     fn encode(&self, e: &mut Vec<u8>) {
         match self {
             TableElemType::Funcref => RefType::Func.encode(e),
-            TableElemType::Anyref => RefType::Any.encode(e),
+            TableElemType::Externref => RefType::Extern.encode(e),
             TableElemType::Exnref => RefType::Exn.encode(e),
         }
     }

--- a/crates/wast/src/resolve/names.rs
+++ b/crates/wast/src/resolve/names.rs
@@ -209,7 +209,9 @@ impl<'a> Resolver<'a> {
 
     fn resolve_valtype(&self, ty: &mut ValType<'a>) -> Result<(), Error> {
         match ty {
-            ValType::Ref(i) | ValType::Optref(i) | ValType::Rtt(i) => {
+            ValType::Ref(RefType::Type(i))
+            | ValType::Ref(RefType::OptType(i))
+            | ValType::Rtt(i) => {
                 self.ns(Ns::Type)
                     .resolve(i)
                     .map_err(|id| self.resolve_error(id, "type"))?;

--- a/crates/wast/src/resolve/names.rs
+++ b/crates/wast/src/resolve/names.rs
@@ -209,9 +209,20 @@ impl<'a> Resolver<'a> {
 
     fn resolve_valtype(&self, ty: &mut ValType<'a>) -> Result<(), Error> {
         match ty {
-            ValType::Ref(RefType::Type(i))
-            | ValType::Ref(RefType::OptType(i))
-            | ValType::Rtt(i) => {
+            ValType::Ref(ty) => self.resolve_reftype(ty)?,
+            ValType::Rtt(i) => {
+                self.ns(Ns::Type)
+                    .resolve(i)
+                    .map_err(|id| self.resolve_error(id, "type"))?;
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    fn resolve_reftype(&self, ty: &mut RefType<'a>) -> Result<(), Error> {
+        match ty {
+            RefType::Type(i) | RefType::OptType(i) => {
                 self.ns(Ns::Type)
                     .resolve(i)
                     .map_err(|id| self.resolve_error(id, "type"))?;
@@ -549,6 +560,8 @@ impl<'a, 'b> ExprResolver<'a, 'b> {
                 self.resolver.resolve_valtype(&mut s.from)?;
                 self.resolver.resolve_valtype(&mut s.to)
             }
+
+            RefNull(ty) | RefIsNull(ty) => self.resolver.resolve_reftype(ty),
 
             _ => Ok(()),
         }

--- a/tests/regression/gc-struct.wat
+++ b/tests/regression/gc-struct.wat
@@ -21,6 +21,5 @@
   (func
     struct.narrow i32 f32
     struct.narrow anyref funcref
-    struct.narrow anyref nullref
   )
 )

--- a/tests/wabt.rs
+++ b/tests/wabt.rs
@@ -505,5 +505,23 @@ fn skip_test(test: &Path, contents: &str) -> bool {
         return true;
     }
 
+    // Waiting for wabt to remove subtyping from reference-types.
+    if test
+        .iter()
+        .any(|x| x == "bulk-memory-operations" || x == "reference-types")
+        || test.ends_with("reference-types.txt")
+        || test.ends_with("all-features.txt")
+        || test.ends_with("all-features.txt")
+        || test.ends_with("bulk-memory-named.txt")
+        || test.ends_with("reference-types-named.txt")
+        || test.ends_with("table-grow.txt")
+        || test.ends_with("result-exnref.txt")
+        || test.ends_with("global-exnref.txt")
+        || test.ends_with("global.txt")
+        || test.ends_with("bulk-memory.txt")
+    {
+        return true;
+    }
+
     false
 }


### PR DESCRIPTION
This is the equivalent of the syntax changes in WebAssembly/reference-types/pull/87. I have a corresponding patch in SpiderMonkey that tests this out with the semantics changes as well.

It may be good to hold off on merging this until the upstream PR is closer to merging, to track any changes. I'm posting this now to just get ready for when that is.